### PR TITLE
Move gopher user to Docker image instead of entrypoint

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -16,10 +16,6 @@ fi
 
 if [ "${PLAYWITHGO_NOGOPHER:-}" != "true" ]
 then
-	USER_UID="${USER_UID:-1000}"
-	USER_GID="${USER_GID:-1000}"
-	groupadd -r -g $USER_GID gopher
-	useradd -s /bin/bash -u $USER_UID -m --no-log-init -r -g gopher gopher
 	cat <<'EOD' >> /home/gopher/.bashrc
 export PS1='$ '
 EOD
@@ -43,7 +39,7 @@ EOD
 	fi
 	cd /home/gopher
 	export HOME=/home/gopher
-	exec setpriv --reuid gopher --regid gopher --init-groups "$@"
+        exec "$@"
 else
 	exec "$@"
 fi

--- a/go1.15.1/Dockerfile
+++ b/go1.15.1/Dockerfile
@@ -5,14 +5,17 @@ RUN echo "deb http://ppa.launchpad.net/git-core/ppa/ubuntu groovy main" > /etc/a
   apt-key adv --keyserver keyserver.ubuntu.com --recv-keys A1715D88E1DF1F24 && \
   apt-get update && \
   apt-get update && \
-  apt-get -y install git=1:2.28.0-0ppa1~ubuntu20.10.1
+  apt-get -y install git=1:2.28.0-0ppa1~ubuntu20.10.1 && \
+  groupadd -r -g 1000 gopher && \
+  useradd -s /bin/bash -u 1000 -m --no-log-init -r -g gopher gopher
 
 # Clean up
 RUN apt-get -y autoremove && \
   apt-get clean
 
+USER gopher
+
 COPY ./entrypoint.sh /usr/bin/entrypoint.sh
-RUN chown root:root /usr/bin/entrypoint.sh
 ENTRYPOINT ["/usr/bin/entrypoint.sh"]
 
 # By default, run bash endlessly. This can be overriden by providing an

--- a/go1.15.1/entrypoint.sh
+++ b/go1.15.1/entrypoint.sh
@@ -16,10 +16,6 @@ fi
 
 if [ "${PLAYWITHGO_NOGOPHER:-}" != "true" ]
 then
-	USER_UID="${USER_UID:-1000}"
-	USER_GID="${USER_GID:-1000}"
-	groupadd -r -g $USER_GID gopher
-	useradd -s /bin/bash -u $USER_UID -m --no-log-init -r -g gopher gopher
 	cat <<'EOD' >> /home/gopher/.bashrc
 export PS1='$ '
 EOD
@@ -43,7 +39,7 @@ EOD
 	fi
 	cd /home/gopher
 	export HOME=/home/gopher
-	exec setpriv --reuid gopher --regid gopher --init-groups "$@"
+        exec "$@"
 else
 	exec "$@"
 fi

--- a/go1.15/Dockerfile
+++ b/go1.15/Dockerfile
@@ -5,14 +5,17 @@ RUN echo "deb http://ppa.launchpad.net/git-core/ppa/ubuntu groovy main" > /etc/a
   apt-key adv --keyserver keyserver.ubuntu.com --recv-keys A1715D88E1DF1F24 && \
   apt-get update && \
   apt-get update && \
-  apt-get -y install git=1:2.28.0-0ppa1~ubuntu20.10.1
+  apt-get -y install git=1:2.28.0-0ppa1~ubuntu20.10.1 && \
+  groupadd -r -g 1000 gopher && \
+  useradd -s /bin/bash -u 1000 -m --no-log-init -r -g gopher gopher
 
 # Clean up
 RUN apt-get -y autoremove && \
   apt-get clean
 
+USER gopher
+
 COPY ./entrypoint.sh /usr/bin/entrypoint.sh
-RUN chown root:root /usr/bin/entrypoint.sh
 ENTRYPOINT ["/usr/bin/entrypoint.sh"]
 
 # By default, run bash endlessly. This can be overriden by providing an


### PR DESCRIPTION
This allows to copy files to the container while keeping the correct
permissions.