### PR TITLE
go: do not set GOPATH

### DIFF
--- a/go1.15.3/Dockerfile
+++ b/go1.15.3/Dockerfile
@@ -30,6 +30,9 @@ RUN chown gopher:gopher /home/gopher/.bashrc /home/gopher/.gitconfig && \
 
 USER 1000
 
+# Do not set GOPATH
+ENV GOPATH=
+
 # By default, run bash endlessly. This can be overriden by providing an
 # alternative command at runtime
 CMD while true ; do /bin/bash; done

--- a/rebuildAndPush.sh
+++ b/rebuildAndPush.sh
@@ -1,6 +1,20 @@
 #!/usr/bin/env bash
 
-set -eu
+set -euo pipefail
+shopt -s inherit_errexit
+
+push=true
+
+while getopts ":b" opt; do
+  case $opt in
+    b)
+      push=false
+      ;;
+    \?)
+      echo "Invalid option: -$OPTARG" >&2
+      ;;
+  esac
+done
 
 command cd "$( command cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
 
@@ -8,6 +22,9 @@ for i in $(find * -mindepth 1 -name Dockerfile -print)
 do
 	i=$(dirname $i)
 	docker build -t playwithgo/$i -f $i/Dockerfile .
-	docker push playwithgo/$i
+	if [ "$push" == "true" ]
+	then
+		docker push playwithgo/$i
+	fi
 done
 


### PR DESCRIPTION
Ensure GOPATH is unset; this gives a situation more realistic to a
first-time user.

Also tweak the rebuildAndPush.sh script to have a -b build-only flag.