### PR TITLE
all: use official docker/dockerfile image

### DIFF
--- a/go1.15.5/Dockerfile
+++ b/go1.15.5/Dockerfile
@@ -1,13 +1,19 @@
-# syntax = docker/dockerfile:experimental@sha256:de85b2f3a3e8a2f7fe48e8e84a65f6fdd5cd5183afa6412fff9caa6871649c44
+# syntax = docker/dockerfile@sha256:e2a8561e419ab1ba6b2fe6cbdf49fd92b95912df1cf7d313c3e2230a333fdbcc
+# SHA256 above is an absolute reference to docker/dockerfile:1.2.1
+
+# The comment regarding the syntax reference is not at the top of the file
+# because the syntax line must be the first in the file.
 
 # golang:1.15.5
 FROM golang@sha256:7ca7ffe692fa0fb6a142d4bdf5c28b6d7b3e32dc9a25eea9596ae1935135d7eb
 
 # Latest git
+#
+# TODO: use of the PPA like this is flakey. Move to a better solution.
 RUN echo "deb http://ppa.launchpad.net/git-core/ppa/ubuntu focal main" > /etc/apt/sources.list.d/git-core-ubuntu-ppa-groovy.list && \
   apt-key adv --keyserver keyserver.ubuntu.com --recv-keys A1715D88E1DF1F24 && \
   apt-get update && \
-  apt-get -y install git=1:2.29.2-0ppa1~ubuntu20.04.1
+  apt-get -y install git=1:2.30.0-0ppa1~ubuntu20.04.1
 
 RUN apt-get -y install sudo vim nano
 

--- a/go1.16-tip/Dockerfile
+++ b/go1.16-tip/Dockerfile
@@ -1,4 +1,8 @@
-# syntax = docker/dockerfile:experimental@sha256:de85b2f3a3e8a2f7fe48e8e84a65f6fdd5cd5183afa6412fff9caa6871649c44
+# syntax = docker/dockerfile@sha256:e2a8561e419ab1ba6b2fe6cbdf49fd92b95912df1cf7d313c3e2230a333fdbcc
+# SHA256 above is an absolute reference to docker/dockerfile:1.2.1
+
+# The comment regarding the syntax reference is not at the top of the file
+# because the syntax line must be the first in the file.
 
 # golang:1.15.2
 FROM golang@sha256:da7ff43658854148b401f24075c0aa390e3b52187ab67cab0043f2b15e754a68 AS stage1
@@ -43,10 +47,12 @@ ENV PATH /usr/local/go/bin:$PATH
 COPY --from=stage1 /gobuild /usr/local/go
 
 # Latest git
+#
+# TODO: use of the PPA like this is flakey. Move to a better solution.
 RUN echo "deb http://ppa.launchpad.net/git-core/ppa/ubuntu focal main" > /etc/apt/sources.list.d/git-core-ubuntu-ppa-groovy.list && \
   apt-key adv --keyserver keyserver.ubuntu.com --recv-keys A1715D88E1DF1F24 && \
   apt-get update && \
-  apt-get -y install git=1:2.29.2-0ppa1~ubuntu20.04.1
+  apt-get -y install git=1:2.30.0-0ppa1~ubuntu20.04.1
 
 RUN apt-get -y install sudo vim nano
 

--- a/installgo1.15.5/Dockerfile
+++ b/installgo1.15.5/Dockerfile
@@ -1,4 +1,8 @@
-# syntax = docker/dockerfile:experimental@sha256:de85b2f3a3e8a2f7fe48e8e84a65f6fdd5cd5183afa6412fff9caa6871649c44
+# syntax = docker/dockerfile@sha256:e2a8561e419ab1ba6b2fe6cbdf49fd92b95912df1cf7d313c3e2230a333fdbcc
+# SHA256 above is an absolute reference to docker/dockerfile:1.2.1
+
+# The comment regarding the syntax reference is not at the top of the file
+# because the syntax line must be the first in the file.
 
 # buildpack-deps:buster-scm, base of golang:1.15.3
 FROM buildpack-deps@sha256:f010c9887ecea10d052247ef8befb79c2d17ea3f92ab6cb05039caab757fb14e


### PR DESCRIPTION
We currently use an experimental version of dockerfile. Use an official
version of the buildkit frontend.