### PR TITLE
Bump gotip to go1.17beta1

### DIFF
--- a/gotip/Dockerfile
+++ b/gotip/Dockerfile
@@ -19,7 +19,7 @@ RUN set -eux; \
   cd /gobuild; \
   git init; \
   git remote add origin https://go.googlesource.com/go; \
-  git fetch origin cd176b361591420f84fcbcaaf0cf24351aed0995; \
+  git fetch origin dc00dc6c6bf3b5554e37f60799aec092276ff807; \
   git checkout FETCH_HEAD;
 
 RUN --mount=type=cache,target=/root/.cache/go set -eux; \


### PR DESCRIPTION
### Motivation
Hey! I'm finishing up a play-with-go guide on shuffling tests; a new Go 1.17 feature.

For this reason, I needed a more recent gotip image until Go 1.17 is officially released.


### The problem
Solved, thanks Marcos!
~Unfortunately, the image cannot be currently built, just by pointing to a newer commit.~
~It either fails with `gpg: keyserver receive failed: Connection timed out` or `Version '1:2.31.1-0ppa1~ubuntu20.04.1' for 'git' was not found`.~